### PR TITLE
Centralize invoice and quote number generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # buildledger_2025
 
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/juud-8/buildledger_2025)
+// trigger CI

--- a/__tests__/identifier.test.ts
+++ b/__tests__/identifier.test.ts
@@ -1,0 +1,16 @@
+import { getNextInvoiceNumber, getNextQuoteNumber } from '../src/utils/identifier';
+import { Invoice } from '../src/types';
+
+describe('identifier utilities', () => {
+  test('generates next invoice number with padding', () => {
+    const invoices: Invoice[] = [
+      { id: '1', type: 'invoice', number: 'INV-0001', date: new Date(), contractorInfo: {} as any, client: {} as any, projectTitle: '', lineItems: [], subtotal:0, materialSubtotal:0, laborSubtotal:0, equipmentSubtotal:0, otherSubtotal:0, taxBreakdown: {materialTax:0,laborTax:0,equipmentTax:0,otherTax:0,totalTax:0}, taxAmount:0, discounts: [], discountAmount:0, total:0, payments: [], balanceDue:0, changeOrders: [], changeOrderTotal:0, isProgressBilling:false, status:'draft', createdAt:new Date(), updatedAt:new Date() }
+    ];
+    expect(getNextInvoiceNumber(invoices)).toBe('INV-0002');
+  });
+
+  test('generates next quote number when none exist', () => {
+    const invoices: Invoice[] = [];
+    expect(getNextQuoteNumber(invoices)).toBe('QUO-0001');
+  });
+});

--- a/src/components/DataManagement.tsx
+++ b/src/components/DataManagement.tsx
@@ -1,7 +1,17 @@
 import React, { useState } from 'react';
 import { Download, Upload, Copy, Archive, Search, Filter, Printer, FileText, Database, RefreshCw, Trash2, Calendar, DollarSign, User, Building2 } from 'lucide-react';
 import { Invoice, Client, ContractorInfo } from '../types';
-import { getInvoices, getClients, getContractorInfo, saveInvoice, saveClient, saveContractorInfo, deleteInvoice, deleteClient } from '../utils/storage';
+import {
+  getInvoices,
+  getClients,
+  getContractorInfo,
+  saveInvoice,
+  saveClient,
+  saveContractorInfo,
+  deleteInvoice,
+  deleteClient
+} from '../utils/storage';
+import { getNextInvoiceNumber, getNextQuoteNumber } from '../utils/identifier';
 import { formatCurrency, formatDate } from '../utils/calculations';
 
 interface DataManagementProps {
@@ -127,7 +137,10 @@ const DataManagement: React.FC<DataManagementProps> = ({ onClose }) => {
     const duplicated: Invoice = {
       ...originalInvoice,
       id: Date.now().toString() + Math.random().toString(36).substr(2, 9),
-      number: generateNextNumber(originalInvoice.type),
+      number:
+        originalInvoice.type === 'invoice'
+          ? getNextInvoiceNumber(getInvoices())
+          : getNextQuoteNumber(getInvoices()),
       date: new Date(),
       status: 'draft',
       createdAt: new Date(),
@@ -140,18 +153,6 @@ const DataManagement: React.FC<DataManagementProps> = ({ onClose }) => {
     alert(`${originalInvoice.type.charAt(0).toUpperCase() + originalInvoice.type.slice(1)} duplicated successfully!`);
   };
 
-  const generateNextNumber = (type: 'invoice' | 'quote'): string => {
-    const invoices = getInvoices();
-    const filtered = invoices.filter(i => i.type === type);
-    const numbers = filtered
-      .map(i => parseInt(i.number.replace(/\D/g, ''), 10))
-      .filter(n => !isNaN(n));
-    
-    const nextNumber = numbers.length > 0 ? Math.max(...numbers) + 1 : 1;
-    const prefix = type === 'invoice' ? 'INV' : 'QUO';
-    
-    return `${prefix}-${nextNumber.toString().padStart(4, '0')}`;
-  };
 
   // Archive functionality
   const archiveInvoice = (invoice: Invoice) => {

--- a/src/components/InvoiceForm.tsx
+++ b/src/components/InvoiceForm.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { FileText, Calendar, User, Building2, MapPin, Save, Download, Eye, RefreshCw, Clock, Palette } from 'lucide-react';
 import { InvoiceFormData, Client, ContractorInfo, LineItem, Invoice, ProjectPhoto } from '../types';
-import { getClients, getContractorInfo, generateNextNumber, saveInvoice, getInvoiceById, convertQuoteToInvoice, updateExpiredQuotes, getTemplateSettings } from '../utils/storage';
+import { getClients, getContractorInfo, saveInvoice, getInvoiceById, convertQuoteToInvoice, updateExpiredQuotes, getTemplateSettings, getInvoices } from '../utils/storage';
+import { getNextInvoiceNumber, getNextQuoteNumber } from '../utils/identifier';
 import { calculateSubtotal, calculateTaxBreakdown, calculateDiscountAmount, calculateBalanceDue, formatCurrency } from '../utils/calculations';
 import { v4 as uuidv4 } from 'uuid';
 import LineItemsForm from './LineItemsForm';
@@ -97,7 +98,10 @@ const InvoiceForm: React.FC<InvoiceFormProps> = ({ editingInvoice, onInvoiceUpda
     } else {
       setFormData(prev => ({
         ...prev,
-        number: generateNextNumber(prev.type)
+        number:
+          prev.type === 'invoice'
+            ? getNextInvoiceNumber(getInvoices())
+            : getNextQuoteNumber(getInvoices())
       }));
     }
   }, [editingInvoice]);
@@ -146,7 +150,10 @@ const InvoiceForm: React.FC<InvoiceFormProps> = ({ editingInvoice, onInvoiceUpda
       setFormData(prev => ({
         ...prev,
         type,
-        number: generateNextNumber(type)
+        number:
+          type === 'invoice'
+            ? getNextInvoiceNumber(getInvoices())
+            : getNextQuoteNumber(getInvoices())
       }));
     }
   };
@@ -334,7 +341,10 @@ const InvoiceForm: React.FC<InvoiceFormProps> = ({ editingInvoice, onInvoiceUpda
       if (!editingInvoice) {
         setFormData(prev => ({
           ...prev,
-          number: generateNextNumber(formData.type),
+          number:
+            formData.type === 'invoice'
+              ? getNextInvoiceNumber(getInvoices())
+              : getNextQuoteNumber(getInvoices()),
           clientId: '',
           projectTitle: '',
           projectDescription: '',

--- a/src/components/InvoiceList.tsx
+++ b/src/components/InvoiceList.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { FileText, Plus, Search, Edit, Trash2, Eye, Download, RefreshCw, Clock, CheckCircle, XCircle, AlertCircle, Calendar, DollarSign, User, Database, Copy, Printer, Archive } from 'lucide-react';
 import { Invoice } from '../types';
-import { getInvoices, deleteInvoice, updateInvoiceStatus, convertQuoteToInvoice, updateExpiredQuotes, saveInvoice, generateNextNumber } from '../utils/storage';
+import { getInvoices, deleteInvoice, updateInvoiceStatus, convertQuoteToInvoice, updateExpiredQuotes, saveInvoice } from '../utils/storage';
+import { getNextInvoiceNumber, getNextQuoteNumber } from '../utils/identifier';
 import { formatDate, formatCurrency } from '../utils/calculations';
 import DataManagement from './DataManagement';
 
@@ -89,7 +90,10 @@ const InvoiceList: React.FC<InvoiceListProps> = ({ onEditInvoice, onCreateNew })
     const duplicated: Invoice = {
       ...originalInvoice,
       id: Date.now().toString() + Math.random().toString(36).substr(2, 9),
-      number: generateNextNumber(originalInvoice.type),
+      number:
+        originalInvoice.type === 'invoice'
+          ? getNextInvoiceNumber(getInvoices())
+          : getNextQuoteNumber(getInvoices()),
       date: new Date(),
       status: 'draft',
       createdAt: new Date(),

--- a/src/utils/identifier.ts
+++ b/src/utils/identifier.ts
@@ -1,0 +1,19 @@
+import { Invoice } from '../types';
+
+export const getNextInvoiceNumber = (invoices: Invoice[]): string => {
+  const numbers = invoices
+    .filter(i => i.type === 'invoice')
+    .map(i => parseInt(i.number.replace(/\D/g, ''), 10))
+    .filter(n => !isNaN(n));
+  const next = numbers.length > 0 ? Math.max(...numbers) + 1 : 1;
+  return `INV-${next.toString().padStart(4, '0')}`;
+};
+
+export const getNextQuoteNumber = (quotes: Invoice[]): string => {
+  const numbers = quotes
+    .filter(q => q.type === 'quote')
+    .map(q => parseInt(q.number.replace(/\D/g, ''), 10))
+    .filter(n => !isNaN(n));
+  const next = numbers.length > 0 ? Math.max(...numbers) + 1 : 1;
+  return `QUO-${next.toString().padStart(4, '0')}`;
+};

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,4 +1,5 @@
 import { Client, Invoice, ContractorInfo, TemplateSettings } from '../types';
+import { getNextInvoiceNumber } from './identifier';
 
 const STORAGE_KEYS = {
   CLIENTS: 'buildledger_clients',
@@ -122,7 +123,7 @@ export const convertQuoteToInvoice = (quoteId: string): Invoice | null => {
   }
 
   // Create new invoice from quote
-  const invoiceNumber = generateNextNumber('invoice');
+  const invoiceNumber = getNextInvoiceNumber(getInvoices());
   const currentDate = new Date();
   const dueDate = new Date(currentDate.getTime() + 30 * 24 * 60 * 60 * 1000); // 30 days from now
 
@@ -237,18 +238,6 @@ export const getDefaultTemplateSettings = (): TemplateSettings => {
 };
 
 // Generate next invoice/quote number
-export const generateNextNumber = (type: 'invoice' | 'quote'): string => {
-  const invoices = getInvoices();
-  const filtered = invoices.filter(i => i.type === type);
-  const numbers = filtered
-    .map(i => parseInt(i.number.replace(/\D/g, ''), 10))
-    .filter(n => !isNaN(n));
-  
-  const nextNumber = numbers.length > 0 ? Math.max(...numbers) + 1 : 1;
-  const prefix = type === 'invoice' ? 'INV' : 'QUO';
-  
-  return `${prefix}-${nextNumber.toString().padStart(4, '0')}`;
-};
 
 // Generate unique ID
 const generateUniqueId = (): string => {


### PR DESCRIPTION
## Summary
- centralize sequential number generation in `identifier` util
- update storage and components to use new utility
- add jest unit tests for identifier utils

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684ca1e5cefc832997c7d0a762f99d25