### PR TITLE
Fix subtotalByCategory logic

### DIFF
--- a/src/components/InvoiceForm.tsx
+++ b/src/components/InvoiceForm.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { FileText, Calendar, User, Building2, MapPin, Save, Download, Eye, RefreshCw, Clock, Palette } from 'lucide-react';
 import { InvoiceFormData, Client, ContractorInfo, LineItem, Invoice, ProjectPhoto } from '../types';
 import { getClients, getContractorInfo, generateNextNumber, saveInvoice, getInvoiceById, convertQuoteToInvoice, updateExpiredQuotes, getTemplateSettings } from '../utils/storage';
-import { calculateSubtotal, calculateTaxBreakdown, calculateDiscountAmount, calculateBalanceDue, formatCurrency } from '../utils/calculations';
+import { calculateTaxBreakdown, calculateDiscountAmount, calculateBalanceDue, formatCurrency, getCategoryTotals } from '../utils/calculations';
 import { v4 as uuidv4 } from 'uuid';
 import LineItemsForm from './LineItemsForm';
 import ClientForm from './ClientForm';
@@ -216,7 +216,8 @@ const InvoiceForm: React.FC<InvoiceFormProps> = ({ editingInvoice, onInvoiceUpda
   };
 
   const calculateTotals = () => {
-    const subtotal = calculateSubtotal(formData.lineItems);
+    const { material, labor, equipment, other } = getCategoryTotals(formData.lineItems);
+    const subtotal = material + labor + equipment + other;
     const taxBreakdown = calculateTaxBreakdown(
       formData.lineItems,
       formData.materialTaxRate,
@@ -228,16 +229,16 @@ const InvoiceForm: React.FC<InvoiceFormProps> = ({ editingInvoice, onInvoiceUpda
     const total = subtotal + taxBreakdown.totalTax - discountAmount;
     const balanceDue = calculateBalanceDue(total, []);
     
-    return { 
-      subtotal, 
-      taxBreakdown, 
-      discountAmount, 
-      total, 
+    return {
+      subtotal,
+      taxBreakdown,
+      discountAmount,
+      total,
       balanceDue,
-      materialSubtotal: taxBreakdown.materialTax > 0 ? subtotal * 0.5 : 0, // Simplified calculation
-      laborSubtotal: taxBreakdown.laborTax > 0 ? subtotal * 0.3 : 0,
-      equipmentSubtotal: taxBreakdown.equipmentTax > 0 ? subtotal * 0.15 : 0,
-      otherSubtotal: taxBreakdown.otherTax > 0 ? subtotal * 0.05 : 0
+      materialSubtotal: material,
+      laborSubtotal: labor,
+      equipmentSubtotal: equipment,
+      otherSubtotal: other
     };
   };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -123,6 +123,13 @@ export interface TaxBreakdown {
   totalTax: number;
 }
 
+export interface CategoryTotals {
+  material: number;
+  labor: number;
+  equipment: number;
+  other: number;
+}
+
 export interface ProjectPhoto {
   id: string;
   url: string;

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -22,6 +22,42 @@ export const calculateSubtotal = (lineItems: LineItem[]): number => {
   return Math.round(lineItems.reduce((sum, item) => sum + item.total, 0) * 100) / 100;
 };
 
+import { CategoryTotals } from '../types';
+
+export function getCategoryTotals(items: LineItem[]): CategoryTotals {
+  const totals = items.reduce(
+    (totals, item) => {
+      const markup = item.markup ?? 0;
+      const itemTotal = item.quantity * item.rate * (1 + markup / 100);
+
+      switch (item.category) {
+        case 'material':
+          totals.material += itemTotal;
+          break;
+        case 'labor':
+          totals.labor += itemTotal;
+          break;
+        case 'equipment':
+          totals.equipment += itemTotal;
+          break;
+        default:
+          totals.other += itemTotal;
+          break;
+      }
+
+      return totals;
+    },
+    { material: 0, labor: 0, equipment: 0, other: 0 }
+  );
+
+  return {
+    material: Math.round(totals.material * 100) / 100,
+    labor: Math.round(totals.labor * 100) / 100,
+    equipment: Math.round(totals.equipment * 100) / 100,
+    other: Math.round(totals.other * 100) / 100
+  };
+}
+
 export const calculateCategoryTotals = (lineItems: LineItem[]) => {
   const materialSubtotal = calculateCategorySubtotal(lineItems, 'material');
   const laborSubtotal = calculateCategorySubtotal(lineItems, 'labor');

--- a/tests/getCategoryTotals.test.ts
+++ b/tests/getCategoryTotals.test.ts
@@ -1,0 +1,18 @@
+import { getCategoryTotals } from '../src/utils/calculations.js';
+import { LineItem } from '../src/types';
+
+const items: LineItem[] = [
+  { id: '1', description: 'Lumber', category: 'material', quantity: 10, unit: 'ft', rate: 5, markup: 10, total: 0 },
+  { id: '2', description: 'Labor', category: 'labor', quantity: 8, unit: 'hr', rate: 20, markup: 0, total: 0 },
+  { id: '3', description: 'Excavator', category: 'equipment', quantity: 2, unit: 'day', rate: 100, markup: 5, total: 0 },
+  { id: '4', description: 'Permit', category: 'other', quantity: 1, unit: 'each', rate: 50, markup: 0, total: 0 }
+];
+
+const totals = getCategoryTotals(items);
+
+if (totals.material !== 55) throw new Error(`material expected 55 got ${totals.material}`);
+if (totals.labor !== 160) throw new Error(`labor expected 160 got ${totals.labor}`);
+if (totals.equipment !== 210) throw new Error(`equipment expected 210 got ${totals.equipment}`);
+if (totals.other !== 50) throw new Error(`other expected 50 got ${totals.other}`);
+
+console.log('getCategoryTotals tests passed.');


### PR DESCRIPTION
## Summary
- add `CategoryTotals` type and `getCategoryTotals` util
- compute category subtotals from line items when saving invoice
- create regression test for `getCategoryTotals`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `node tests/out/tests/getCategoryTotals.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684ca710b95c83299553ae7105ebfa20