### PR TITLE
Add import/export helpers

### DIFF
--- a/src/components/DataManagement.tsx
+++ b/src/components/DataManagement.tsx
@@ -1,7 +1,18 @@
 import React, { useState } from 'react';
 import { Download, Upload, Copy, Archive, Search, Filter, Printer, FileText, Database, RefreshCw, Trash2, Calendar, DollarSign, User, Building2 } from 'lucide-react';
 import { Invoice, Client, ContractorInfo } from '../types';
-import { getInvoices, getClients, getContractorInfo, saveInvoice, saveClient, saveContractorInfo, deleteInvoice, deleteClient } from '../utils/storage';
+import {
+  getInvoices,
+  getClients,
+  getContractorInfo,
+  saveInvoice,
+  saveClient,
+  saveContractorInfo,
+  deleteInvoice,
+  deleteClient
+} from '../utils/storage';
+import { buildExportBlob } from '../utils/exporter';
+import { importFromBlob } from '../utils/importer';
 import { formatCurrency, formatDate } from '../utils/calculations';
 
 interface DataManagementProps {
@@ -21,21 +32,28 @@ const DataManagement: React.FC<DataManagementProps> = ({ onClose }) => {
   const [isSearching, setIsSearching] = useState(false);
 
   // Export functionality
+  const downloadBlob = (blob: Blob, filename: string) => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
   const exportData = (type: 'all' | 'invoices' | 'clients' | 'settings') => {
     let data: any = {};
     let filename = '';
 
     switch (type) {
-      case 'all':
-        data = {
-          invoices: getInvoices(),
-          clients: getClients(),
-          contractorInfo: getContractorInfo(),
-          exportDate: new Date().toISOString(),
-          version: '1.0'
-        };
+      case 'all': {
         filename = `buildledger-complete-backup-${new Date().toISOString().split('T')[0]}.json`;
-        break;
+        const blob = buildExportBlob();
+        downloadBlob(blob, filename);
+        return;
+      }
       case 'invoices':
         data = {
           invoices: getInvoices(),
@@ -60,66 +78,26 @@ const DataManagement: React.FC<DataManagementProps> = ({ onClose }) => {
     }
 
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, filename);
   };
 
   // Import functionality
-  const handleImport = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
 
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      try {
-        const data = JSON.parse(e.target?.result as string);
-        
-        if (data.invoices) {
-          data.invoices.forEach((invoice: any) => {
-            // Convert date strings back to Date objects
-            const convertedInvoice = {
-              ...invoice,
-              date: new Date(invoice.date),
-              dueDate: invoice.dueDate ? new Date(invoice.dueDate) : undefined,
-              expiryDate: invoice.expiryDate ? new Date(invoice.expiryDate) : undefined,
-              createdAt: new Date(invoice.createdAt),
-              updatedAt: new Date(invoice.updatedAt),
-              client: {
-                ...invoice.client,
-                createdAt: new Date(invoice.client.createdAt)
-              }
-            };
-            saveInvoice(convertedInvoice);
-          });
-        }
+    const confirmImport = window.confirm(
+      'Importing data will merge with existing records. Continue?'
+    );
+    if (!confirmImport) return;
 
-        if (data.clients) {
-          data.clients.forEach((client: any) => {
-            const convertedClient = {
-              ...client,
-              createdAt: new Date(client.createdAt)
-            };
-            saveClient(convertedClient);
-          });
-        }
-
-        if (data.contractorInfo) {
-          saveContractorInfo(data.contractorInfo);
-        }
-
-        alert('Data imported successfully!');
-        window.location.reload(); // Refresh to show imported data
-      } catch (error) {
-        alert('Error importing data. Please check the file format.');
-      }
-    };
-    reader.readAsText(file);
+    const success = await importFromBlob(file);
+    if (success) {
+      alert('Data imported successfully!');
+      window.location.reload();
+    } else {
+      alert('Error importing data. Please check the file format.');
+    }
   };
 
   // Duplicate invoice/quote

--- a/src/utils/exporter.ts
+++ b/src/utils/exporter.ts
@@ -1,0 +1,9 @@
+import { exportAllData } from './storage';
+
+/**
+ * Build a Blob containing all user data in JSON format.
+ */
+export const buildExportBlob = (): Blob => {
+  const data = exportAllData();
+  return new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+};

--- a/src/utils/importer.ts
+++ b/src/utils/importer.ts
@@ -1,0 +1,25 @@
+import { importData } from './storage';
+
+/**
+ * Merge data from a JSON Blob into local storage or Supabase.
+ * Currently Supabase integration is not implemented and falls back to local storage.
+ */
+export const importFromBlob = async (
+  blob: Blob,
+  supabaseClient?: any
+): Promise<boolean> => {
+  try {
+    const text = await blob.text();
+    const data = JSON.parse(text);
+
+    if (supabaseClient && typeof supabaseClient.from === 'function') {
+      // Placeholder for Supabase merge logic
+      console.warn('Supabase import not implemented; using local storage.');
+    }
+
+    return importData(data);
+  } catch (err) {
+    console.error('Import failed:', err);
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary
- add utilities to export and import a single JSON backup
- hook Data Management page into new importer/exporter

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cafd0785c8329850f01d83d2289a3