### PR TITLE
Add Jest setup and example tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  }
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -32,6 +33,12 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.4",
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/jest-dom": "^6.2.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/src/components/InvoiceForm.test.tsx
+++ b/src/components/InvoiceForm.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import InvoiceForm from './InvoiceForm';
+import type { Client, ContractorInfo, Invoice, LineItem, TaxBreakdown } from '../types';
+
+jest.mock('../utils/storage', () => ({
+  getClients: jest.fn(),
+  getContractorInfo: jest.fn(),
+  generateNextNumber: jest.fn(),
+  saveInvoice: jest.fn(),
+  getInvoiceById: jest.fn(),
+  convertQuoteToInvoice: jest.fn(),
+  updateExpiredQuotes: jest.fn(),
+  getTemplateSettings: jest.fn()
+}));
+
+import * as storage from '../utils/storage';
+
+describe('InvoiceForm', () => {
+  const mockClient: Client = {
+    id: '1',
+    name: 'Client One',
+    address: '123 St',
+    city: 'Town',
+    state: 'TX',
+    zipCode: '75001',
+    phone: '123',
+    email: 'c1@test.com',
+    createdAt: new Date()
+  };
+
+  const mockContractor: ContractorInfo = {
+    name: 'My Biz',
+    address: '456 St',
+    city: 'Town',
+    state: 'TX',
+    zipCode: '75002',
+    phone: '321',
+    email: 'biz@test.com',
+    licenseNumber: 'LIC-1'
+  };
+
+  const mockTemplateSettings = {
+    id: 'modern',
+    name: 'Modern',
+    type: 'modern',
+    colorScheme: {
+      primary: '#000',
+      secondary: '#000',
+      accent: '#000',
+      text: '#000',
+      background: '#fff',
+      border: '#000'
+    },
+    headerStyle: 'standard',
+    footerStyle: 'standard',
+    showLogo: true,
+    showProjectPhotos: false,
+    showDetailedBreakdown: true,
+    fontFamily: 'Arial',
+    fontSize: 'medium'
+  };
+
+  const lineItem: LineItem = {
+    id: 'l1',
+    description: 'Item',
+    category: 'material',
+    quantity: 1,
+    unit: 'ea',
+    rate: 10,
+    total: 10
+  };
+
+  const taxBreakdown: TaxBreakdown = {
+    materialTax: 0.8,
+    laborTax: 0,
+    equipmentTax: 0,
+    otherTax: 0,
+    totalTax: 0.8
+  };
+
+  const invoice: Invoice = {
+    id: 'i1',
+    type: 'invoice',
+    number: 'INV-0001',
+    date: new Date(),
+    dueDate: new Date(),
+    contractorInfo: mockContractor,
+    client: mockClient,
+    projectTitle: 'Test Project',
+    lineItems: [lineItem],
+    subtotal: 10,
+    materialSubtotal: 10,
+    laborSubtotal: 0,
+    equipmentSubtotal: 0,
+    otherSubtotal: 0,
+    taxBreakdown,
+    taxAmount: 0.8,
+    discounts: [],
+    discountAmount: 0,
+    total: 10.8,
+    depositAmount: 0,
+    payments: [],
+    balanceDue: 10.8,
+    changeOrders: [],
+    changeOrderTotal: 0,
+    progressBilling: [],
+    isProgressBilling: false,
+    templateSettings: mockTemplateSettings,
+    terms: '',
+    notes: '',
+    status: 'draft',
+    createdAt: new Date(),
+    updatedAt: new Date()
+  };
+
+  beforeEach(() => {
+    (storage.getClients as jest.Mock).mockReturnValue([mockClient]);
+    (storage.getContractorInfo as jest.Mock).mockReturnValue(mockContractor);
+    (storage.generateNextNumber as jest.Mock).mockReturnValue('INV-0001');
+    (storage.getTemplateSettings as jest.Mock).mockReturnValue(mockTemplateSettings);
+  });
+
+  test('submits and calls onSave', () => {
+    const onSave = jest.fn();
+    render(<InvoiceForm editingInvoice={invoice} onInvoiceUpdated={onSave} />);
+    const button = screen.getByRole('button', { name: /update invoice/i });
+    fireEvent.click(button);
+    expect(onSave).toHaveBeenCalled();
+    expect(storage.saveInvoice).toHaveBeenCalled();
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/utils/calculations.test.ts
+++ b/src/utils/calculations.test.ts
@@ -1,0 +1,44 @@
+import { calculateCategoryTotals, calculateTaxBreakdown, calculateDiscountAmount } from './calculations';
+import type { LineItem, Discount } from '../types';
+
+describe('calculations utilities', () => {
+  const lineItems: LineItem[] = [
+    { id: '1', description: 'Wood', category: 'material', quantity: 2, unit: 'pcs', rate: 10, total: 20 },
+    { id: '2', description: 'Labor', category: 'labor', quantity: 1, unit: 'hr', rate: 15, total: 15 },
+    { id: '3', description: 'Excavator', category: 'equipment', quantity: 1, unit: 'unit', rate: 50, total: 50 },
+    { id: '4', description: 'Permit', category: 'other', quantity: 1, unit: 'each', rate: 5, total: 5, taxRate: 5 }
+  ];
+
+  test('getCategoryTotals', () => {
+    const totals = calculateCategoryTotals(lineItems);
+    expect(totals).toEqual({
+      materialSubtotal: 20,
+      laborSubtotal: 15,
+      equipmentSubtotal: 50,
+      otherSubtotal: 5
+    });
+  });
+
+  test('tax breakdown', () => {
+    const taxes = calculateTaxBreakdown(lineItems, 8, 0, 8, 8);
+    expect(taxes).toEqual({
+      materialTax: 1.6,
+      laborTax: 0,
+      equipmentTax: 4,
+      otherTax: 0.25,
+      totalTax: 5.85
+    });
+  });
+
+  test('discount calculations', () => {
+    const discounts: Discount[] = [
+      { type: 'percentage', value: 10, description: '10%', appliesTo: 'subtotal' },
+      { type: 'fixed', value: 5, description: '$5 off materials', appliesTo: 'category', category: 'material' }
+    ];
+
+    const subtotal = 90;
+    const total = 95.85;
+    const amount = calculateDiscountAmount(subtotal, total, discounts, lineItems);
+    expect(amount).toBe(14);
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest using ts-jest and add RTL setup
- create sample tests for calculations utils
- create a basic test for InvoiceForm component
- expose `npm test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cafe6a548832984db593df082f981