### PR TITLE
Fix tests and invoice form attachments

### DIFF
--- a/src/components/InvoiceForm.tsx
+++ b/src/components/InvoiceForm.tsx
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useToast } from './ui/Toast';
 import { FileText, Calendar, User, Building2, MapPin, Save, Download, Eye, RefreshCw, Clock, Palette } from 'lucide-react';
-import { InvoiceFormData, Client, ContractorInfo, LineItem, Invoice, ProjectPhoto } from '../types';
+import { InvoiceFormData, Client, ContractorInfo, LineItem, Invoice, ProjectPhoto, TemplateSettings, Discount } from '../types';
 import { getClients, getContractorInfo, saveInvoice, getInvoiceById, convertQuoteToInvoice, updateExpiredQuotes, getTemplateSettings, getInvoices } from '../utils/storage';
 import { getNextInvoiceNumber, getNextQuoteNumber } from '../utils/identifier';
 import { useCreateInvoice, useUpdateInvoice } from '../hooks/useInvoices';
@@ -94,7 +94,8 @@ const toast = useToast();
     progressPhases: [],
     templateSettings: getTemplateSettings(),
     terms: '',
-    notes: ''
+    notes: '',
+    attachments: []
   });
 
   useEffect(() => {
@@ -168,7 +169,8 @@ const toast = useToast();
       progressPhases: invoice.progressBilling || [],
       templateSettings: invoice.templateSettings || getTemplateSettings(),
       terms: invoice.terms || '',
-      notes: invoice.notes || ''
+      notes: invoice.notes || '',
+      attachments: invoice.attachments || []
     });
     setCurrentInvoice(invoice);
   };
@@ -338,9 +340,10 @@ const toast = useToast();
       
       // Template settings
       templateSettings: formData.templateSettings,
-      
+
       terms: formData.terms || undefined,
       notes: formData.notes || undefined,
+      attachments: formData.attachments,
       status: editingInvoice?.status || 'draft',
       originalQuoteId: editingInvoice?.originalQuoteId,
       convertedInvoiceId: editingInvoice?.convertedInvoiceId,
@@ -411,7 +414,8 @@ mutation.mutate(invoice, {
         projectPhotos: [],
         lineItems: [],
         discounts: [],
-        notes: ''
+        notes: '',
+        attachments: []
       }));
     }
   },

--- a/src/utils/constructionStorage.ts
+++ b/src/utils/constructionStorage.ts
@@ -33,9 +33,9 @@ export const getMaterialDatabase = (): MaterialItem[] => {
       lastUpdated: new Date(material.lastUpdated),
       priceHistory: material.priceHistory
         ? material.priceHistory.map(entry => ({
-          ...entry,
-          date: new Date(entry.date)
-        })
+            ...entry,
+            date: new Date(entry.date)
+          }))
         : []
     }));
   } catch {

--- a/tests/getCategoryTotals.test.ts
+++ b/tests/getCategoryTotals.test.ts
@@ -1,18 +1,21 @@
 import { getCategoryTotals } from '../src/utils/calculations';
-import { LineItem } from '../src/types';
+import type { LineItem } from '../src/types';
 
-const items: LineItem[] = [
-  { id: '1', description: 'Lumber', category: 'material', quantity: 10, unit: 'ft', rate: 5, markup: 10, total: 0 },
-  { id: '2', description: 'Labor', category: 'labor', quantity: 8, unit: 'hr', rate: 20, markup: 0, total: 0 },
-  { id: '3', description: 'Excavator', category: 'equipment', quantity: 2, unit: 'day', rate: 100, markup: 5, total: 0 },
-  { id: '4', description: 'Permit', category: 'other', quantity: 1, unit: 'each', rate: 50, markup: 0, total: 0 }
-];
+describe('getCategoryTotals', () => {
+  test('calculates totals for common categories', () => {
+    const items: LineItem[] = [
+      { id: '1', description: 'Lumber', category: 'material', quantity: 10, unit: 'ft', rate: 5, markup: 10, total: 0 },
+      { id: '2', description: 'Labor', category: 'labor', quantity: 8, unit: 'hr', rate: 20, markup: 0, total: 0 },
+      { id: '3', description: 'Excavator', category: 'equipment', quantity: 2, unit: 'day', rate: 100, markup: 5, total: 0 },
+      { id: '4', description: 'Permit', category: 'other', quantity: 1, unit: 'each', rate: 50, markup: 0, total: 0 }
+    ];
 
-const totals = getCategoryTotals(items);
+    const totals = getCategoryTotals(items);
 
-if (totals.material !== 55) throw new Error(`material expected 55 got ${totals.material}`);
-if (totals.labor !== 160) throw new Error(`labor expected 160 got ${totals.labor}`);
-if (totals.equipment !== 210) throw new Error(`equipment expected 210 got ${totals.equipment}`);
-if (totals.other !== 50) throw new Error(`other expected 50 got ${totals.other}`);
+    expect(totals).toEqual({ material: 55, labor: 160, equipment: 210, other: 50 });
+  });
 
-console.log('getCategoryTotals tests passed.');
+  test('stub', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add missing TemplateSettings and Discount types to InvoiceForm
- track attachments in invoice form state
- fix syntax error in constructionStorage
- convert getCategoryTotals test to Jest and add stub

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850498638bc8329b7436ce3e193f1cc